### PR TITLE
Let MongoDB filter execute parts of the input filter

### DIFF
--- a/src/main/java/notaql/engines/mongodb/FilterTranslator.java
+++ b/src/main/java/notaql/engines/mongodb/FilterTranslator.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2015 by Thomas Lottermann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package notaql.engines.mongodb;
+
+import notaql.datamodel.Step;
+import notaql.model.EvaluationException;
+import notaql.model.path.BoundIdStep;
+import notaql.model.path.InputPath;
+import notaql.model.path.InputPathStep;
+import notaql.model.predicate.*;
+import notaql.model.vdata.AtomVData;
+import notaql.model.vdata.InputVData;
+import notaql.model.vdata.VData;
+import org.bson.BSONObject;
+import org.bson.BasicBSONObject;
+import org.bson.types.BasicBSONList;
+
+/**
+ * Created by thomas on 12.06.15.
+ */
+public class FilterTranslator {
+    public static BSONObject toMongoDBQuery(Predicate filter) {
+        // Drop all incompatible parts of the predicate
+        final Predicate reducedFilter = reducePredicate(filter);
+        // Convert to MongoDB query
+        final BSONObject query = translatePredicate(reducedFilter);
+
+        return query;
+    }
+
+    /**
+     * Translates compatible predicates to MongoDB queries
+     * @param predicate
+     * @return
+     */
+    private static BSONObject translatePredicate(Predicate predicate) {
+        if(predicate instanceof LogicalOperationPredicate)
+            return translateLogicalOperationPredicate((LogicalOperationPredicate) predicate);
+        if(predicate instanceof NegatedPredicate)
+            return translateNegatedPredicate((NegatedPredicate) predicate);
+        if(predicate instanceof PathExistencePredicate)
+            return translatePathExistencePredicate((PathExistencePredicate) predicate);
+        if(predicate instanceof RelationalPredicate)
+            return translateRelationalPredicate((RelationalPredicate) predicate);
+
+        throw new EvaluationException("Unknown predicate: " + predicate.toString());
+    }
+
+    private static BSONObject translateRelationalPredicate(RelationalPredicate predicate) {
+        final VData left = predicate.getLeft();
+        final VData right = predicate.getRight();
+
+        assert left instanceof AtomVData && right instanceof InputVData || right instanceof AtomVData && left instanceof InputVData;
+
+        final InputVData field;
+        final AtomVData value;
+        final String op;
+
+        if(right instanceof AtomVData) {
+            field = (InputVData)left;
+            value = (AtomVData)right;
+            switch (predicate.getOperator()) {
+                case LT:
+                    op = "$lt";
+                    break;
+                case LTEQ:
+                    op = "$lte";
+                    break;
+                case GT:
+                    op = "$gt";
+                    break;
+                case GTEQ:
+                    op = "$gte";
+                    break;
+                case EQ:
+                    op = "$eq";
+                    break;
+                case NEQ:
+                    op = "$ne";
+                    break;
+                default:
+                    throw new EvaluationException("Unexpected operator: " + predicate.getOperator());
+            }
+        } else {
+            field = (InputVData)right;
+            value = (AtomVData)left;
+            switch (predicate.getOperator()) {
+                case LT:
+                    op = "$gt";
+                    break;
+                case LTEQ:
+                    op = "$gte";
+                    break;
+                case GT:
+                    op = "$lt";
+                    break;
+                case GTEQ:
+                    op = "$lte";
+                    break;
+                case EQ:
+                    op = "$eq";
+                    break;
+                case NEQ:
+                    op = "$ne";
+                    break;
+                default:
+                    throw new EvaluationException("Unexpected operator: " + predicate.getOperator());
+            }
+        }
+
+        assert field.getPath().getPathSteps().size() == 1 && field.getPath().getPathSteps().get(0) instanceof BoundIdStep;
+
+        final Step step = ((BoundIdStep) field.getPath().getPathSteps().get(0)).getId();
+
+        assert step.getStep() instanceof String;
+
+        return new BasicBSONObject((String)step.getStep(), new BasicBSONObject(op, value.getValue().getValue()));
+    }
+
+    private static BSONObject translatePathExistencePredicate(PathExistencePredicate predicate) {
+        assert predicate.getPath().getPathSteps().size() == 1 && predicate.getPath().getPathSteps().get(0) instanceof BoundIdStep;
+
+        final String step = ((BoundIdStep) predicate.getPath().getPathSteps().get(0)).getId().toString();
+
+        final BasicBSONObject query = new BasicBSONObject();
+        query.put(step, new BasicBSONObject("$exists", true));
+        return query;
+    }
+
+    private static BSONObject translateNegatedPredicate(NegatedPredicate predicate) {
+        final BasicBSONList norList = new BasicBSONList();
+        norList.add(translatePredicate(predicate.getPredicate()));
+
+        return new BasicBSONObject("$nor", norList);
+    }
+
+    private static BSONObject translateLogicalOperationPredicate(LogicalOperationPredicate predicate) {
+        final BasicBSONList opList = new BasicBSONList();
+        opList.add(translatePredicate(predicate.getLeft()));
+        opList.add(translatePredicate(predicate.getRight()));
+
+        final String op;
+
+        if(predicate.getOperator().equals(LogicalOperationPredicate.Operator.AND))
+            op = "$and";
+        else if(predicate.getOperator().equals(LogicalOperationPredicate.Operator.OR))
+            op = "$or";
+        else
+            throw new EvaluationException("Unexpected operator: " + predicate.getOperator());
+
+        return new BasicBSONObject(op, opList);
+    }
+
+    /**
+     * Drops all incompatible parts of a predicate tree
+     * @param predicate
+     * @return
+     */
+    private static Predicate reducePredicate(Predicate predicate) {
+        if(predicate instanceof LogicalOperationPredicate)
+            return reduceLogicalOperationPredicate((LogicalOperationPredicate) predicate);
+        if(predicate instanceof NegatedPredicate)
+            return reduceNegatedPredicate((NegatedPredicate) predicate);
+        if(predicate instanceof PathExistencePredicate)
+            return reducePathExistencePredicate((PathExistencePredicate) predicate);
+        if(predicate instanceof RelationalPredicate)
+            return reduceRelationalPredicate((RelationalPredicate) predicate);
+
+        throw new EvaluationException("Unknown predicate: " + predicate.toString());
+    }
+
+    private static Predicate reduceRelationalPredicate(RelationalPredicate predicate) {
+        final VData left = reduceVData(predicate.getLeft());
+        final VData right = reduceVData(predicate.getRight());
+
+        if(left != null && right != null && (left instanceof AtomVData && right instanceof InputVData || right instanceof AtomVData && left instanceof InputVData))
+            return new RelationalPredicate(left, right, predicate.getOperator());
+
+        return null;
+    }
+
+    private static Predicate reducePathExistencePredicate(PathExistencePredicate predicate) {
+        final InputPath path = reduceInputPath(predicate.getPath());
+
+        if(path != null)
+            return new PathExistencePredicate(path);
+
+        return null;
+    }
+
+    private static Predicate reduceNegatedPredicate(NegatedPredicate predicate) {
+        final Predicate reduced = reducePredicate(predicate.getPredicate());
+
+        if(reduced != null)
+            return new NegatedPredicate(reduced);
+
+        return null;
+    }
+
+    private static Predicate reduceLogicalOperationPredicate(LogicalOperationPredicate predicate) {
+        final Predicate left = reducePredicate(predicate.getLeft());
+        final Predicate right = reducePredicate(predicate.getRight());
+
+        // TODO: This may allow more complex stuff: AND would be okay here for example
+        if(left != null && right != null)
+            return new LogicalOperationPredicate(left, right, predicate.getOperator());
+
+        return null;
+    }
+
+    private static VData reduceVData(VData vData) {
+        if(vData instanceof AtomVData)
+            return reduceAtomVData((AtomVData) vData);
+        if(vData instanceof InputVData)
+            return reduceInputVData((InputVData) vData);
+        return null;
+    }
+
+    private static VData reduceInputVData(InputVData vData) {
+        final InputPath path = reduceInputPath(vData.getPath());
+        if(path != null)
+            return new InputVData(path);
+
+        return null;
+    }
+
+    private static InputPath reduceInputPath(InputPath path) {
+        if(path.getPathSteps().size() != 1)
+            return null;
+        final InputPathStep step = path.getPathSteps().get(0);
+        if(step instanceof BoundIdStep)
+            return new InputPath(step);
+
+        return null;
+    }
+
+    private static VData reduceAtomVData(AtomVData vData) {
+        return new AtomVData(vData.getValue());
+    }
+
+
+}

--- a/src/main/java/notaql/engines/mongodb/MongoDBEngineEvaluator.java
+++ b/src/main/java/notaql/engines/mongodb/MongoDBEngineEvaluator.java
@@ -110,13 +110,20 @@ public class MongoDBEngineEvaluator implements EngineEvaluator {
         Configuration config = new Configuration();
         config.set("mongo.input.uri", mongoDBHost + databaseName + "." + collectionName);
 
+        // add partial filter to query in mongodb
+        if(transformation.getInPredicate() != null) {
+            final BSONObject query = FilterTranslator.toMongoDBQuery(transformation.getInPredicate());
+            logger.info("Sending query to MongoDB: " + query.toString());
+            config.set("mongo.input.query", query.toString());
+        }
+
         final SparkTransformationEvaluator evaluator = new SparkTransformationEvaluator(transformation);
 
         JavaPairRDD<Object, BSONObject> mongoRDD = sc.newAPIHadoopRDD(config, MongoInputFormat.class, Object.class, BSONObject.class);
 
         // convert all objects in rdd to inner format
         final JavaRDD<Value> converted = mongoRDD.map(t -> ValueConverter.convertToNotaQL(t._2));
-        // filter the ones not fulfilling the input filter
+        // filter the ones not fulfilling the input filter (queries of MongoDB are less expressive than NotaQL)
         final JavaRDD<Value> filtered = converted.filter(v -> transformation.satisfiesInPredicate((ObjectValue) v));
 
         // process all input
@@ -137,7 +144,6 @@ public class MongoDBEngineEvaluator implements EngineEvaluator {
 
         Configuration config = new Configuration();
         config.set("mongo.output.uri", mongoDBHost + databaseName + "." + collectionName);
-        // TODO: use mongo.input.query for executing parts in mongodb (https://github.com/mongodb/mongo-hadoop/wiki/Configuration-Reference#mongoinputquery)
 
         JavaPairRDD<Object,BSONObject> output = result.mapToPair(
                 o -> new Tuple2<>(null, (DBObject)ValueConverter.convertFromNotaQL(o))

--- a/src/main/java/notaql/engines/mongodb/MongoDBEngineEvaluator.java
+++ b/src/main/java/notaql/engines/mongodb/MongoDBEngineEvaluator.java
@@ -137,6 +137,7 @@ public class MongoDBEngineEvaluator implements EngineEvaluator {
 
         Configuration config = new Configuration();
         config.set("mongo.output.uri", mongoDBHost + databaseName + "." + collectionName);
+        // TODO: use mongo.input.query for executing parts in mongodb (https://github.com/mongodb/mongo-hadoop/wiki/Configuration-Reference#mongoinputquery)
 
         JavaPairRDD<Object,BSONObject> output = result.mapToPair(
                 o -> new Tuple2<>(null, (DBObject)ValueConverter.convertFromNotaQL(o))

--- a/src/main/java/notaql/model/path/IdStep.java
+++ b/src/main/java/notaql/model/path/IdStep.java
@@ -45,6 +45,10 @@ public class IdStep<T> implements InputPathStep, OutputPathStep {
         return Arrays.asList(new StepNameEvaluationResult(fixation, step, id));
     }
 
+    public Step<T> getId() {
+        return id;
+    }
+
     @Override
     public String toString() {
         return id.toString();

--- a/src/test/java/notaql/NotaQLMongoDBTest.java
+++ b/src/test/java/notaql/NotaQLMongoDBTest.java
@@ -75,6 +75,36 @@ public class NotaQLMongoDBTest {
     }
 
     @Test
+    public void testExistenceInFilter() throws Exception {
+        createPaperIn();
+        String transformation = engines +
+                "IN-FILTER: IN.children," +
+                "OUT._id <- IN._id;";
+
+        NotaQL.evaluate(transformation);
+    }
+
+    @Test
+    public void testSimpleInFilter() throws Exception {
+        createPaperIn();
+        String transformation = engines +
+                "IN-FILTER: IN.info.salary > 50000," +
+                "OUT._id <- IN._id;";
+
+        NotaQL.evaluate(transformation);
+    }
+
+    @Test
+    public void testSimpleInFilterReversed() throws Exception {
+        createPaperIn();
+        String transformation = engines +
+                "IN-FILTER:  50000 < IN.info.salary," +
+                "OUT._id <- IN._id;";
+
+        NotaQL.evaluate(transformation);
+    }
+
+    @Test
     public void testTranspose() throws Exception {
         createPaperIn();
         String transformation = engines +

--- a/src/test/java/notaql/engines/mongodb/FilterTranslatorTest.java
+++ b/src/test/java/notaql/engines/mongodb/FilterTranslatorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 by Thomas Lottermann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package notaql.engines.mongodb;
+
+import org.junit.Test;
+
+/**
+ * Created by thomas on 27.01.15.
+ */
+public class FilterTranslatorTest {
+    @Test
+    public void testExistence() throws Exception {
+
+    }
+
+}


### PR DESCRIPTION
This is the first evolution of the MongoDB engine. It is now able to translate (parts) of the input filters to MongoDB query expressions and thus factor let MongoDB do part of the job.
This should enable us to facilitate existing indexes in MongoDB in order to speed up selective transformations dramatically.
